### PR TITLE
feat: add OPA Gatekeeper for Kubernetes policy-as-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ gcp-devops-iac/
   - TFSec: Security vulnerability scanning
   - Checkov: Policy-as-code compliance
   - TFLint: Best practices enforcement
+- **OPA Gatekeeper**: Kubernetes policy-as-code
+  - Block privileged containers
+  - Enforce resource limits
+  - Restrict image registries
+  - Require labels and probes
 
 ## Monitoring & Observability
 

--- a/docs/gatekeeper-policies.md
+++ b/docs/gatekeeper-policies.md
@@ -1,0 +1,277 @@
+# OPA Gatekeeper Policies
+
+Kubernetes Policy-as-Code menggunakan OPA Gatekeeper untuk enforce security dan best practices.
+
+## Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Kubernetes API                            │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                   Admission Controller                            │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │                    OPA Gatekeeper                          │  │
+│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │  │
+│  │  │ Constraint  │  │ Constraint  │  │ Constraint  │        │  │
+│  │  │ Templates   │  │   (Rules)   │  │   Audit     │        │  │
+│  │  └─────────────┘  └─────────────┘  └─────────────┘        │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                    ┌────────┴────────┐
+                    │  Allow / Deny   │
+                    └─────────────────┘
+```
+
+## Policies Implemented
+
+### Security Policies
+
+| Policy | Action | Description |
+|--------|--------|-------------|
+| Block Privileged | deny | Block containers running in privileged mode |
+| Block Host Namespace | deny | Block hostNetwork, hostPID, hostIPC |
+| Allowed Repos | deny | Restrict images to approved registries |
+| Block Latest Tag | warn | Prevent use of :latest tag |
+
+### Resource Management
+
+| Policy | Action | Description |
+|--------|--------|-------------|
+| Require Resources | deny | Require CPU/memory limits and requests |
+| Require Probes | warn | Require liveness/readiness probes |
+
+### Best Practices
+
+| Policy | Action | Description |
+|--------|--------|-------------|
+| Require Labels | deny | Require app, team, environment labels |
+
+## Installation
+
+### 1. Install Gatekeeper
+
+```bash
+# Using kubectl
+kubectl apply -k kubernetes/gatekeeper/base/
+
+# Or using Helm (recommended for production)
+helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+helm install gatekeeper gatekeeper/gatekeeper \
+  --namespace gatekeeper-system \
+  --create-namespace \
+  --set replicas=3 \
+  --set auditInterval=60
+```
+
+### 2. Apply Constraint Templates
+
+```bash
+kubectl apply -k kubernetes/gatekeeper/templates/
+```
+
+### 3. Apply Constraints
+
+```bash
+kubectl apply -k kubernetes/gatekeeper/constraints/
+```
+
+### 4. Apply All at Once
+
+```bash
+kubectl apply -k kubernetes/gatekeeper/
+```
+
+## Policy Details
+
+### K8sRequiredLabels
+
+Requires specified labels on resources.
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: require-labels
+spec:
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment"]
+  parameters:
+    labels:
+      - key: app
+      - key: team
+      - key: environment
+        allowedRegex: "^(dev|staging|prod)$"
+```
+
+**Example violation:**
+```yaml
+# This will be REJECTED - missing required labels
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+    # Missing: team, environment
+```
+
+### K8sBlockPrivileged
+
+Blocks privileged containers.
+
+```yaml
+# This will be REJECTED
+containers:
+  - name: my-container
+    securityContext:
+      privileged: true  # NOT ALLOWED
+```
+
+### K8sRequiredResources
+
+Requires resource limits and requests.
+
+```yaml
+# This will be REJECTED - missing resources
+containers:
+  - name: my-container
+    image: my-image:v1
+    # Missing: resources.limits, resources.requests
+
+# Correct configuration:
+containers:
+  - name: my-container
+    image: my-image:v1
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+```
+
+### K8sAllowedRepos
+
+Restricts images to approved registries.
+
+```yaml
+# This will be REJECTED - unauthorized registry
+containers:
+  - name: my-container
+    image: untrusted-registry.com/my-image:v1
+
+# Allowed registries:
+# - asia-southeast1-docker.pkg.dev/
+# - gcr.io/
+# - docker.io/library/
+```
+
+### K8sBlockLatestTag
+
+Blocks :latest tag usage.
+
+```yaml
+# This will generate WARNING
+containers:
+  - name: my-container
+    image: my-image:latest  # NOT RECOMMENDED
+
+# Correct:
+containers:
+  - name: my-container
+    image: my-image:v1.2.3  # Specific version
+```
+
+## Enforcement Actions
+
+| Action | Behavior |
+|--------|----------|
+| `deny` | Block the request immediately |
+| `warn` | Allow but show warning message |
+| `dryrun` | Log only, don't enforce |
+
+## Checking Violations
+
+### View All Violations
+
+```bash
+kubectl get constraints -o wide
+```
+
+### View Specific Constraint Violations
+
+```bash
+kubectl describe k8srequiredlabels require-labels-on-deployments
+```
+
+### Audit Existing Resources
+
+```bash
+# View audit results
+kubectl get k8srequiredlabels -o yaml | grep -A 100 violations
+```
+
+## Exemptions
+
+### Exclude Namespaces
+
+```yaml
+spec:
+  match:
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+      - my-exempt-namespace
+```
+
+### Exclude Specific Images
+
+```yaml
+spec:
+  parameters:
+    exemptImages:
+      - "gcr.io/google-containers/*"
+      - "*/special-image:*"
+```
+
+## Troubleshooting
+
+### Check Gatekeeper Status
+
+```bash
+kubectl get pods -n gatekeeper-system
+kubectl logs -n gatekeeper-system -l control-plane=controller-manager
+```
+
+### Check Constraint Status
+
+```bash
+kubectl get constrainttemplates
+kubectl get constraints
+```
+
+### Debug Denied Requests
+
+```bash
+# View rejection reason
+kubectl describe k8sblockprivileged block-privileged-containers
+
+# Check Gatekeeper webhook logs
+kubectl logs -n gatekeeper-system deployment/gatekeeper-controller-manager
+```
+
+## Best Practices
+
+1. **Start with `warn`** - Use warn action initially, then switch to deny
+2. **Exclude system namespaces** - Always exclude kube-system and gatekeeper-system
+3. **Use audit mode** - Enable audit to find existing violations
+4. **Document exemptions** - Always document why an exemption is needed
+5. **Version constraints** - Use GitOps to manage constraint versions

--- a/kubernetes/gatekeeper/base/config.yaml
+++ b/kubernetes/gatekeeper/base/config.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Gatekeeper Configuration
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: gatekeeper-system
+spec:
+  # Sync resources to OPA for referential constraints
+  sync:
+    syncOnly:
+      - group: ""
+        version: "v1"
+        kind: "Namespace"
+      - group: ""
+        version: "v1"
+        kind: "Pod"
+      - group: ""
+        version: "v1"
+        kind: "Service"
+      - group: "networking.k8s.io"
+        version: "v1"
+        kind: "Ingress"
+  # Exempt namespaces from admission control
+  match:
+    - excludedNamespaces:
+        - gatekeeper-system
+        - kube-system
+        - kube-public
+        - kube-node-lease
+        - cert-manager
+      processes:
+        - "*"
+  # Validation configuration
+  validation:
+    traces:
+      - user: "*"
+        kind:
+          group: ""
+          version: "v1"
+          kind: "Pod"

--- a/kubernetes/gatekeeper/base/gatekeeper.yaml
+++ b/kubernetes/gatekeeper/base/gatekeeper.yaml
@@ -1,0 +1,259 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# OPA Gatekeeper Installation via Helm
+#
+# To install Gatekeeper, run:
+# helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+# helm install gatekeeper/gatekeeper --name-template=gatekeeper --namespace gatekeeper-system --create-namespace
+#
+# Or use this HelmRelease with Flux/ArgoCD:
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gatekeeper-admin
+  namespace: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gatekeeper-manager-role
+  labels:
+    app.kubernetes.io/name: gatekeeper
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["config.gatekeeper.sh"]
+    resources: ["configs"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["config.gatekeeper.sh"]
+    resources: ["configs/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["constraints.gatekeeper.sh"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["constrainttemplates"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["constrainttemplates/finalizers"]
+    verbs: ["delete", "get", "patch", "update"]
+  - apiGroups: ["templates.gatekeeper.sh"]
+    resources: ["constrainttemplates/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["status.gatekeeper.sh"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gatekeeper-manager-rolebinding
+  labels:
+    app.kubernetes.io/name: gatekeeper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gatekeeper-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: gatekeeper-admin
+    namespace: gatekeeper-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatekeeper-webhook-server-cert
+  namespace: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gatekeeper-webhook-service
+  namespace: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/name: gatekeeper
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-controller-manager
+  namespace: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+    control-plane: controller-manager
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gatekeeper
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gatekeeper
+        control-plane: controller-manager
+    spec:
+      serviceAccountName: gatekeeper-admin
+      containers:
+        - name: manager
+          image: openpolicyagent/gatekeeper:v3.14.0
+          args:
+            - --port=8443
+            - --logtostderr
+            - --exempt-namespace=gatekeeper-system
+            - --exempt-namespace=kube-system
+            - --operation=webhook
+            - --operation=mutation-webhook
+            - --disable-cert-rotation
+          ports:
+            - containerPort: 8443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8888
+              name: metrics
+              protocol: TCP
+            - containerPort: 9090
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /certs
+              name: cert
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: gatekeeper-webhook-server-cert
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - gatekeeper
+                topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+    control-plane: audit-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gatekeeper
+      control-plane: audit-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gatekeeper
+        control-plane: audit-controller
+    spec:
+      serviceAccountName: gatekeeper-admin
+      containers:
+        - name: manager
+          image: openpolicyagent/gatekeeper:v3.14.0
+          args:
+            - --logtostderr
+            - --operation=audit
+            - --operation=status
+            - --audit-interval=60
+            - --audit-chunk-size=500
+            - --audit-from-cache
+            - --constraint-violations-limit=100
+          ports:
+            - containerPort: 8888
+              name: metrics
+              protocol: TCP
+            - containerPort: 9090
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000

--- a/kubernetes/gatekeeper/base/kustomization.yaml
+++ b/kubernetes/gatekeeper/base/kustomization.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: gatekeeper-system
+
+resources:
+  - namespace.yaml
+  - gatekeeper.yaml
+  - config.yaml

--- a/kubernetes/gatekeeper/base/namespace.yaml
+++ b/kubernetes/gatekeeper/base/namespace.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Gatekeeper System Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatekeeper-system
+  labels:
+    app.kubernetes.io/name: gatekeeper
+    app.kubernetes.io/component: admission-controller
+    control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
+    admission.gatekeeper.sh/ignore: "no-self-managing"

--- a/kubernetes/gatekeeper/constraints/allowed-repos.yaml
+++ b/kubernetes/gatekeeper/constraints/allowed-repos.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Constraint: Restrict images to allowed registries
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAllowedRepos
+metadata:
+  name: allowed-image-repos
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    repos:
+      # GCP Artifact Registry - replace PROJECT_ID with your actual project
+      - "asia-southeast1-docker.pkg.dev/"
+      - "us-docker.pkg.dev/"
+      - "europe-docker.pkg.dev/"
+      # Google Container Registry (legacy)
+      - "gcr.io/"
+      - "asia.gcr.io/"
+      - "eu.gcr.io/"
+      - "us.gcr.io/"
+      # Official images
+      - "docker.io/library/"
+      - "ghcr.io/"
+      # Common trusted registries
+      - "quay.io/"
+      - "registry.k8s.io/"
+---
+# Constraint: Block :latest tag
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockLatestTag
+metadata:
+  name: block-latest-tag
+spec:
+  enforcementAction: warn  # Start with warn, change to deny when ready
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    exemptImages: []

--- a/kubernetes/gatekeeper/constraints/block-privileged.yaml
+++ b/kubernetes/gatekeeper/constraints/block-privileged.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Constraint: Block privileged containers
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockPrivileged
+metadata:
+  name: block-privileged-containers
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    exemptImages:
+      # Allow specific system images that require privileged mode
+      - "gcr.io/google-containers/*"
+---
+# Constraint: Block host namespaces
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockHostNamespace
+metadata:
+  name: block-host-namespace
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    allowHostNetwork: false
+    allowHostPID: false
+    allowHostIPC: false

--- a/kubernetes/gatekeeper/constraints/kustomization.yaml
+++ b/kubernetes/gatekeeper/constraints/kustomization.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - require-labels.yaml
+  - block-privileged.yaml
+  - require-resources.yaml
+  - allowed-repos.yaml
+  - require-probes.yaml

--- a/kubernetes/gatekeeper/constraints/require-labels.yaml
+++ b/kubernetes/gatekeeper/constraints/require-labels.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Constraint: Require standard labels on all deployments
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: require-labels-on-deployments
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    message: "All deployments must have 'app', 'team', and 'environment' labels"
+    labels:
+      - key: app
+        allowedRegex: "^[a-z0-9-]+$"
+      - key: team
+        allowedRegex: "^[a-z0-9-]+$"
+      - key: environment
+        allowedRegex: "^(dev|staging|prod)$"
+---
+# Constraint: Require app label on all pods
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  name: require-app-label-on-pods
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    message: "All pods should have an 'app' label"
+    labels:
+      - key: app

--- a/kubernetes/gatekeeper/constraints/require-probes.yaml
+++ b/kubernetes/gatekeeper/constraints/require-probes.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Constraint: Require health probes on deployments
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredProbes
+metadata:
+  name: require-probes
+spec:
+  enforcementAction: warn  # Start with warn, change to deny when ready
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    probes:
+      - readinessProbe
+      - livenessProbe
+    exemptImages:
+      # Init containers and jobs typically don't need probes
+      - "*/busybox:*"
+      - "*/alpine:*"

--- a/kubernetes/gatekeeper/constraints/require-resources.yaml
+++ b/kubernetes/gatekeeper/constraints/require-resources.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Constraint: Require resource limits and requests
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredResources
+metadata:
+  name: require-resource-limits
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet"]
+    excludedNamespaces:
+      - kube-system
+      - gatekeeper-system
+  parameters:
+    limits:
+      - memory
+      - cpu
+    requests:
+      - memory
+      - cpu
+    exemptImages:
+      # System images that may not need resource limits
+      - "k8s.gcr.io/*"
+      - "gcr.io/google-containers/*"

--- a/kubernetes/gatekeeper/kustomization.yaml
+++ b/kubernetes/gatekeeper/kustomization.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Main Kustomization for Gatekeeper
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base/
+  - templates/
+  - constraints/

--- a/kubernetes/gatekeeper/templates/k8s-allowed-repos.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-allowed-repos.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Restrict container images to allowed registries
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sallowedrepos
+  annotations:
+    description: >-
+      Requires container images to begin with a string from a specified list.
+      Use this to restrict images to approved registries only.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sAllowedRepos
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            repos:
+              type: array
+              description: List of allowed image registry prefixes
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sallowedrepos
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not image_matches_allowed(container.image)
+          msg := sprintf("Container <%v> has an invalid image repo <%v>. Allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }
+
+        image_matches_allowed(image) {
+          repo := input.parameters.repos[_]
+          startswith(image, repo)
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }

--- a/kubernetes/gatekeeper/templates/k8s-block-host-namespace.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-block-host-namespace.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Block hostNetwork, hostPID, hostIPC
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockhostnamespace
+  annotations:
+    description: >-
+      Blocks pods from sharing the host's network, PID, or IPC namespaces.
+      These settings can break container isolation and pose security risks.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockHostNamespace
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowHostNetwork:
+              type: boolean
+              description: Allow hostNetwork
+            allowHostPID:
+              type: boolean
+              description: Allow hostPID
+            allowHostIPC:
+              type: boolean
+              description: Allow hostIPC
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sblockhostnamespace
+
+        violation[{"msg": msg}] {
+          not input_allow_host_network
+          input.review.object.spec.hostNetwork == true
+          msg := "hostNetwork is not allowed. Pods should not share the host's network namespace."
+        }
+
+        violation[{"msg": msg}] {
+          not input_allow_host_pid
+          input.review.object.spec.hostPID == true
+          msg := "hostPID is not allowed. Pods should not share the host's PID namespace."
+        }
+
+        violation[{"msg": msg}] {
+          not input_allow_host_ipc
+          input.review.object.spec.hostIPC == true
+          msg := "hostIPC is not allowed. Pods should not share the host's IPC namespace."
+        }
+
+        input_allow_host_network {
+          input.parameters.allowHostNetwork == true
+        }
+
+        input_allow_host_pid {
+          input.parameters.allowHostPID == true
+        }
+
+        input_allow_host_ipc {
+          input.parameters.allowHostIPC == true
+        }

--- a/kubernetes/gatekeeper/templates/k8s-block-latest-tag.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-block-latest-tag.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Block images with :latest tag
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblocklatestag
+  annotations:
+    description: >-
+      Blocks container images using the :latest tag or no tag at all.
+      Immutable tags ensure reproducible deployments.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockLatestTag
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              type: array
+              description: Images exempt from this policy
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sblocklatestag
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          has_latest_tag(container.image)
+          msg := sprintf("Container <%v> uses :latest tag. Use a specific version tag instead: %v", [container.name, container.image])
+        }
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          has_no_tag(container.image)
+          msg := sprintf("Container <%v> has no image tag. Use a specific version tag: %v", [container.name, container.image])
+        }
+
+        has_latest_tag(image) {
+          endswith(image, ":latest")
+        }
+
+        has_no_tag(image) {
+          not contains(image, ":")
+        }
+
+        has_no_tag(image) {
+          # Handle case where image has digest but no tag
+          contains(image, "@")
+          parts := split(image, "@")
+          not contains(parts[0], ":")
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }
+
+        is_exempt(container) {
+          exempt_images := object.get(input, ["parameters", "exemptImages"], [])
+          img := container.image
+          exemption := exempt_images[_]
+          glob.match(exemption, ["/"], img)
+        }

--- a/kubernetes/gatekeeper/templates/k8s-block-privileged.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-block-privileged.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Block privileged containers
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sblockprivileged
+  annotations:
+    description: >-
+      Blocks containers from running in privileged mode.
+      Privileged containers have root-level access to the host.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sBlockPrivileged
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptImages:
+              type: array
+              description: >-
+                Images that are exempt from this policy.
+                Supports glob patterns.
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sblockprivileged
+
+        import future.keywords.in
+
+        violation[{"msg": msg, "details": {"container": container.name}}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          container.securityContext.privileged == true
+          msg := sprintf("Privileged container is not allowed: %v", [container.name])
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.ephemeralContainers[_]
+        }
+
+        is_exempt(container) {
+          exempt_images := object.get(input, ["parameters", "exemptImages"], [])
+          img := container.image
+          exemption := exempt_images[_]
+          glob.match(exemption, ["/"], img)
+        }

--- a/kubernetes/gatekeeper/templates/k8s-required-labels.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-required-labels.yaml
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Require specific labels on resources
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredlabels
+  annotations:
+    description: >-
+      Requires resources to contain specified labels with values matching
+      provided regular expressions.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            message:
+              type: string
+            labels:
+              type: array
+              description: >-
+                A list of labels that must be present on the resource.
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The required label key.
+                  allowedRegex:
+                    type: string
+                    description: >-
+                      Regex that the label value must match. If not provided,
+                      any value is allowed.
+                required:
+                  - key
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredlabels
+
+        get_message(parameters, _default) = msg {
+          not parameters.message
+          msg := _default
+        }
+
+        get_message(parameters, _default) = msg {
+          msg := parameters.message
+        }
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+          provided := {label | input.review.object.metadata.labels[label]}
+          required := {label | label := input.parameters.labels[_].key}
+          missing := required - provided
+          count(missing) > 0
+          def_msg := sprintf("You must provide labels: %v", [missing])
+          msg := get_message(input.parameters, def_msg)
+        }
+
+        violation[{"msg": msg}] {
+          value := input.review.object.metadata.labels[key]
+          expected := input.parameters.labels[_]
+          expected.key == key
+          expected.allowedRegex != ""
+          not re_match(expected.allowedRegex, value)
+          def_msg := sprintf("Label <%v: %v> does not match regex %v", [key, value, expected.allowedRegex])
+          msg := get_message(input.parameters, def_msg)
+        }

--- a/kubernetes/gatekeeper/templates/k8s-required-probes.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-required-probes.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Require liveness and readiness probes
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredprobes
+  annotations:
+    description: >-
+      Requires containers to have liveness and/or readiness probes defined.
+      Probes help Kubernetes manage container health and traffic routing.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredProbes
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            probes:
+              type: array
+              description: List of required probes (livenessProbe, readinessProbe, startupProbe)
+              items:
+                type: string
+            exemptImages:
+              type: array
+              description: Images exempt from this policy
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredprobes
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          probe := input.parameters.probes[_]
+          not has_probe(container, probe)
+          msg := sprintf("Container <%v> does not have <%v> defined", [container.name, probe])
+        }
+
+        has_probe(container, "livenessProbe") {
+          container.livenessProbe
+        }
+
+        has_probe(container, "readinessProbe") {
+          container.readinessProbe
+        }
+
+        has_probe(container, "startupProbe") {
+          container.startupProbe
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+
+        is_exempt(container) {
+          exempt_images := object.get(input, ["parameters", "exemptImages"], [])
+          img := container.image
+          exemption := exempt_images[_]
+          glob.match(exemption, ["/"], img)
+        }

--- a/kubernetes/gatekeeper/templates/k8s-required-resources.yaml
+++ b/kubernetes/gatekeeper/templates/k8s-required-resources.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ConstraintTemplate: Require resource limits and requests
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srequiredresources
+  annotations:
+    description: >-
+      Requires containers to have resource limits and requests set.
+      This ensures proper resource allocation and prevents resource starvation.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRequiredResources
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            limits:
+              type: array
+              description: List of required resource limits (cpu, memory)
+              items:
+                type: string
+            requests:
+              type: array
+              description: List of required resource requests (cpu, memory)
+              items:
+                type: string
+            exemptImages:
+              type: array
+              description: Images exempt from this policy
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8srequiredresources
+
+        import future.keywords.in
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          required_limits := object.get(input.parameters, "limits", [])
+          limit := required_limits[_]
+          not has_limit(container, limit)
+          msg := sprintf("Container <%v> does not have resource limit <%v> set", [container.name, limit])
+        }
+
+        violation[{"msg": msg}] {
+          container := input_containers[_]
+          not is_exempt(container)
+          required_requests := object.get(input.parameters, "requests", [])
+          request := required_requests[_]
+          not has_request(container, request)
+          msg := sprintf("Container <%v> does not have resource request <%v> set", [container.name, request])
+        }
+
+        has_limit(container, limit) {
+          container.resources.limits[limit]
+        }
+
+        has_request(container, request) {
+          container.resources.requests[request]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+
+        is_exempt(container) {
+          exempt_images := object.get(input, ["parameters", "exemptImages"], [])
+          img := container.image
+          exemption := exempt_images[_]
+          glob.match(exemption, ["/"], img)
+        }

--- a/kubernetes/gatekeeper/templates/kustomization.yaml
+++ b/kubernetes/gatekeeper/templates/kustomization.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - k8s-required-labels.yaml
+  - k8s-block-privileged.yaml
+  - k8s-required-resources.yaml
+  - k8s-allowed-repos.yaml
+  - k8s-block-latest-tag.yaml
+  - k8s-block-host-namespace.yaml
+  - k8s-required-probes.yaml


### PR DESCRIPTION
## Summary
Implement OPA Gatekeeper untuk Kubernetes admission control dengan comprehensive security dan best practices policies.

## Policies Implemented

### Security (Enforcement: deny)
| Policy | Description |
|--------|-------------|
| Block Privileged | Block containers with privileged: true |
| Block Host Namespace | Block hostNetwork, hostPID, hostIPC |
| Allowed Repos | Restrict to approved image registries |
| Require Resources | Enforce CPU/memory limits and requests |

### Best Practices (Enforcement: warn)
| Policy | Description |
|--------|-------------|
| Block Latest Tag | Prevent :latest tag usage |
| Require Probes | Require liveness/readiness probes |
| Require Labels | Require app, team, environment labels |

## Files Added
```
kubernetes/gatekeeper/
├── base/                    # Gatekeeper installation
│   ├── namespace.yaml
│   ├── gatekeeper.yaml
│   ├── config.yaml
│   └── kustomization.yaml
├── templates/               # ConstraintTemplates (Rego)
│   ├── k8s-required-labels.yaml
│   ├── k8s-block-privileged.yaml
│   ├── k8s-required-resources.yaml
│   ├── k8s-allowed-repos.yaml
│   ├── k8s-block-latest-tag.yaml
│   ├── k8s-block-host-namespace.yaml
│   ├── k8s-required-probes.yaml
│   └── kustomization.yaml
├── constraints/             # Constraint resources
│   └── *.yaml
└── kustomization.yaml

docs/gatekeeper-policies.md  # Documentation
```

## Installation
```bash
kubectl apply -k kubernetes/gatekeeper/
```

## Test Plan
- [ ] Verify ConstraintTemplates syntax is valid
- [ ] Test constraint enforcement with sample deployments
- [ ] Verify excluded namespaces are not affected
- [ ] Verify warn vs deny behavior

Closes #3