### PR TITLE
feat: add Sealed Secrets for GitOps secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ gcp-devops-iac/
 │   └── outputs.tf
 ├── kubernetes/
 │   ├── argocd/             # ArgoCD manifests
+│   ├── gatekeeper/         # OPA Gatekeeper policies
+│   ├── sealed-secrets/     # Sealed Secrets controller
 │   ├── prometheus/         # Prometheus stack
 │   ├── grafana/            # Grafana dashboards
 │   └── apps/               # Application deployments
@@ -177,6 +179,10 @@ gcp-devops-iac/
   - Enforce resource limits
   - Restrict image registries
   - Require labels and probes
+- **Sealed Secrets**: GitOps-friendly secret management
+  - Encrypt secrets for Git storage
+  - Automatic decryption in cluster
+  - ArgoCD integration
 
 ## Monitoring & Observability
 

--- a/docs/sealed-secrets.md
+++ b/docs/sealed-secrets.md
@@ -1,0 +1,323 @@
+# Sealed Secrets for GitOps
+
+Copyright (c) 2024 Bima Kharisma Wicaksana
+
+## Overview
+
+Sealed Secrets adalah solusi untuk menyimpan Kubernetes Secrets secara aman di Git repository. Secret di-encrypt menggunakan public key dari cluster, sehingga hanya cluster yang bisa decrypt.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        GitOps Flow                               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Developer                Git Repository              Cluster    │
+│  ┌────────┐              ┌─────────────┐         ┌──────────┐   │
+│  │ Secret │──kubeseal───▶│ SealedSecret│──ArgoCD─▶│  Secret  │   │
+│  │ (YAML) │              │   (YAML)    │   Sync   │(Decrypted)│  │
+│  └────────┘              └─────────────┘         └──────────┘   │
+│       │                        │                      ▲         │
+│       │                        │                      │         │
+│       ▼                        ▼                      │         │
+│  ┌────────────────────────────────────────────────────┘         │
+│  │              Sealed Secrets Controller                        │
+│  │  • Holds private key                                          │
+│  │  • Decrypts SealedSecrets                                    │
+│  │  • Creates native Secrets                                     │
+│  └──────────────────────────────────────────────────────────────│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Installation
+
+### Prerequisites
+
+```bash
+# Install kubeseal CLI
+# macOS
+brew install kubeseal
+
+# Linux
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.24.5/kubeseal-0.24.5-linux-amd64.tar.gz
+tar -xvzf kubeseal-0.24.5-linux-amd64.tar.gz
+sudo mv kubeseal /usr/local/bin/
+```
+
+### Deploy Controller
+
+Controller di-deploy via ArgoCD:
+
+```bash
+# ArgoCD akan sync dari kubernetes/sealed-secrets/
+kubectl apply -f kubernetes/argocd/applications/sealed-secrets.yaml
+```
+
+Atau manual dengan kustomize:
+
+```bash
+kubectl apply -k kubernetes/sealed-secrets/
+```
+
+## Usage
+
+### 1. Create a Secret (Don't Commit This!)
+
+```bash
+# Generic secret
+kubectl create secret generic my-secret \
+  --from-literal=username=admin \
+  --from-literal=password=supersecret \
+  --dry-run=client -o yaml > my-secret.yaml
+```
+
+### 2. Seal the Secret
+
+```bash
+# Seal using cluster's public key
+kubeseal --format yaml < my-secret.yaml > my-sealed-secret.yaml
+
+# Delete the plain secret!
+rm my-secret.yaml
+```
+
+### 3. Commit SealedSecret
+
+```bash
+# Safe to commit
+git add my-sealed-secret.yaml
+git commit -m "Add sealed secret for my-app"
+git push
+```
+
+### 4. Apply or Let ArgoCD Sync
+
+```bash
+# Manual apply
+kubectl apply -f my-sealed-secret.yaml
+
+# Or let ArgoCD sync automatically
+```
+
+## Secret Types
+
+### Database Credentials
+
+```bash
+kubectl create secret generic db-credentials \
+  --from-literal=DB_HOST=postgres.example.com \
+  --from-literal=DB_PORT=5432 \
+  --from-literal=DB_NAME=myapp \
+  --from-literal=DB_USER=appuser \
+  --from-literal=DB_PASSWORD=secretpassword \
+  --dry-run=client -o yaml | kubeseal --format yaml > db-sealed.yaml
+```
+
+### Docker Registry
+
+```bash
+kubectl create secret docker-registry regcred \
+  --docker-server=asia-southeast1-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat service-account-key.json)" \
+  --docker-email=sa@project.iam.gserviceaccount.com \
+  --dry-run=client -o yaml | kubeseal --format yaml > regcred-sealed.yaml
+```
+
+### TLS Certificate
+
+```bash
+kubectl create secret tls my-tls \
+  --cert=path/to/tls.crt \
+  --key=path/to/tls.key \
+  --dry-run=client -o yaml | kubeseal --format yaml > tls-sealed.yaml
+```
+
+### API Keys
+
+```bash
+kubectl create secret generic api-keys \
+  --from-literal=STRIPE_KEY=sk_live_xxx \
+  --from-literal=SENDGRID_KEY=SG.xxx \
+  --dry-run=client -o yaml | kubeseal --format yaml > api-keys-sealed.yaml
+```
+
+## Advanced Usage
+
+### Namespace Scoping
+
+By default, SealedSecrets are scoped to a specific namespace:
+
+```bash
+# Secret only valid in 'production' namespace
+kubectl create secret generic my-secret \
+  --namespace production \
+  --from-literal=key=value \
+  --dry-run=client -o yaml | kubeseal --format yaml > sealed.yaml
+```
+
+### Cluster-wide Secrets
+
+```bash
+# Can be deployed to any namespace
+kubeseal --scope cluster-wide --format yaml < secret.yaml > sealed.yaml
+```
+
+### Update Existing Secret
+
+```bash
+# Merge new values into existing SealedSecret
+kubeseal --merge-into existing-sealed.yaml < new-secret.yaml
+```
+
+### Fetch Public Key
+
+```bash
+# Get controller's public key for offline sealing
+kubeseal --fetch-cert > pub-cert.pem
+
+# Use offline
+kubeseal --cert pub-cert.pem --format yaml < secret.yaml > sealed.yaml
+```
+
+## Key Management
+
+### Backup Sealing Key
+
+```bash
+# IMPORTANT: Backup the sealing key for disaster recovery
+kubectl get secret -n sealed-secrets -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml > sealing-key-backup.yaml
+
+# Store securely (NOT in Git!)
+```
+
+### Key Rotation
+
+The controller automatically generates new keys periodically. Old keys are kept to decrypt existing SealedSecrets.
+
+To force rotation:
+
+```bash
+kubectl annotate secret -n sealed-secrets \
+  -l sealedsecrets.bitnami.com/sealed-secrets-key \
+  sealedsecrets.bitnami.com/sealed-secrets-key-rotation=true
+```
+
+### Restore Key (Disaster Recovery)
+
+```bash
+# Restore from backup before controller starts
+kubectl apply -f sealing-key-backup.yaml
+
+# Restart controller
+kubectl rollout restart deployment sealed-secrets-controller -n sealed-secrets
+```
+
+## Integration with ArgoCD
+
+### Application Structure
+
+```
+kubernetes/
+├── my-app/
+│   ├── deployment.yaml
+│   ├── service.yaml
+│   └── sealed-secrets/
+│       ├── db-credentials.yaml      # SealedSecret
+│       └── api-keys.yaml            # SealedSecret
+└── sealed-secrets/
+    └── base/                        # Controller
+```
+
+### Sync Order
+
+ArgoCD syncs resources in order. SealedSecrets are processed before Deployments that reference them:
+
+```yaml
+# In your Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - secretRef:
+            name: db-credentials  # Created from SealedSecret
+```
+
+## Troubleshooting
+
+### Check Controller Status
+
+```bash
+kubectl get pods -n sealed-secrets
+kubectl logs -n sealed-secrets -l name=sealed-secrets-controller
+```
+
+### Verify SealedSecret
+
+```bash
+# Check if SealedSecret is synced
+kubectl get sealedsecret my-secret -n default
+
+# Check resulting Secret
+kubectl get secret my-secret -n default
+kubectl get secret my-secret -n default -o jsonpath='{.data}' | base64 -d
+```
+
+### Common Issues
+
+1. **"no key could decrypt secret"**
+   - Key was rotated or cluster was recreated
+   - Solution: Re-seal secrets with new public key
+
+2. **"cannot fetch certificate"**
+   - Controller not running
+   - Solution: Check controller pod status
+
+3. **"namespace mismatch"**
+   - SealedSecret was created for different namespace
+   - Solution: Re-seal with correct namespace
+
+## Security Best Practices
+
+1. **Never commit plain Secrets**
+   - Add `*.secret.yaml` to `.gitignore`
+   - Only commit SealedSecrets
+
+2. **Backup sealing keys**
+   - Store in secure vault (not Git!)
+   - Required for disaster recovery
+
+3. **Use namespace scoping**
+   - Prevents secrets from being used in wrong namespace
+
+4. **Rotate secrets regularly**
+   - Re-seal with new values periodically
+
+5. **Audit access**
+   - Monitor who can access sealed-secrets namespace
+
+## File Structure
+
+```
+kubernetes/sealed-secrets/
+├── base/
+│   ├── namespace.yaml           # Namespace definition
+│   ├── crd.yaml                 # SealedSecret CRD
+│   ├── controller.yaml          # Controller deployment
+│   └── kustomization.yaml
+├── examples/
+│   ├── README.md                # Usage examples
+│   ├── database-secret.yaml     # Template
+│   ├── docker-registry-secret.yaml
+│   └── tls-secret.yaml
+└── kustomization.yaml
+```
+
+## References
+
+- [Sealed Secrets GitHub](https://github.com/bitnami-labs/sealed-secrets)
+- [Sealed Secrets Documentation](https://sealed-secrets.netlify.app/)
+- [ArgoCD + Sealed Secrets](https://argo-cd.readthedocs.io/en/stable/operator-manual/secret-management/)

--- a/kubernetes/argocd/applications/gatekeeper.yaml
+++ b/kubernetes/argocd/applications/gatekeeper.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ArgoCD Application for OPA Gatekeeper
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gatekeeper
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: gatekeeper
+    app.kubernetes.io/component: security
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/bimakw/gcp-devops-iac.git
+    targetRevision: main
+    path: kubernetes/gatekeeper
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gatekeeper-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/kubernetes/argocd/applications/sealed-secrets.yaml
+++ b/kubernetes/argocd/applications/sealed-secrets.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# ArgoCD Application for Sealed Secrets
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+    app.kubernetes.io/component: infrastructure
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/bimakw/gcp-devops-iac.git
+    targetRevision: main
+    path: kubernetes/sealed-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sealed-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/kubernetes/sealed-secrets/base/controller.yaml
+++ b/kubernetes/sealed-secrets/base/controller.yaml
@@ -1,0 +1,198 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Sealed Secrets Controller
+# Based on Bitnami Sealed Secrets v0.24.x
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sealed-secrets-controller
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secrets-unsealer
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+rules:
+  - apiGroups: ["bitnami.com"]
+    resources: ["sealedsecrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["bitnami.com"]
+    resources: ["sealedsecrets/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sealed-secrets-controller
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secrets-unsealer
+subjects:
+  - kind: ServiceAccount
+    name: sealed-secrets-controller
+    namespace: sealed-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sealed-secrets-key-admin
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sealed-secrets-key-admin
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sealed-secrets-key-admin
+subjects:
+  - kind: ServiceAccount
+    name: sealed-secrets-controller
+    namespace: sealed-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sealed-secrets-service-proxier
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["sealed-secrets-controller"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["sealed-secrets-controller", "http:sealed-secrets-controller:", "http:sealed-secrets-controller:http"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sealed-secrets-service-proxier
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sealed-secrets-service-proxier
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sealed-secrets-controller
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 8081
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: sealed-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sealed-secrets-controller
+  namespace: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sealed-secrets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sealed-secrets
+    spec:
+      serviceAccountName: sealed-secrets-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 65534
+      containers:
+        - name: controller
+          image: bitnami/sealed-secrets-controller:0.24.5
+          imagePullPolicy: IfNotPresent
+          args:
+            - --update-status
+            - --key-prefix=sealed-secrets-key
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/sealed-secrets/base/crd.yaml
+++ b/kubernetes/sealed-secrets/base/crd.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# SealedSecret Custom Resource Definition
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sealedsecrets.bitnami.com
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                encryptedData:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                template:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Status
+          type: string
+          jsonPath: .status.conditions[0].message
+        - name: Synced
+          type: string
+          jsonPath: .status.conditions[0].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/kubernetes/sealed-secrets/base/kustomization.yaml
+++ b/kubernetes/sealed-secrets/base/kustomization.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sealed-secrets
+
+resources:
+  - namespace.yaml
+  - crd.yaml
+  - controller.yaml

--- a/kubernetes/sealed-secrets/base/namespace.yaml
+++ b/kubernetes/sealed-secrets/base/namespace.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Sealed Secrets Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sealed-secrets
+  labels:
+    app.kubernetes.io/name: sealed-secrets
+    app.kubernetes.io/component: controller

--- a/kubernetes/sealed-secrets/examples/README.md
+++ b/kubernetes/sealed-secrets/examples/README.md
@@ -1,0 +1,85 @@
+# Sealed Secrets Examples
+
+This directory contains example SealedSecrets templates.
+
+## How to Create a SealedSecret
+
+### 1. Install kubeseal CLI
+
+```bash
+# macOS
+brew install kubeseal
+
+# Linux
+KUBESEAL_VERSION=0.24.5
+wget "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz"
+tar -xvzf kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz
+sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+```
+
+### 2. Create a regular Secret
+
+```yaml
+# secret.yaml (DO NOT COMMIT THIS!)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+type: Opaque
+stringData:
+  username: admin
+  password: super-secret-password
+```
+
+### 3. Seal the Secret
+
+```bash
+# Fetch the public key from the cluster
+kubeseal --fetch-cert \
+  --controller-name=sealed-secrets-controller \
+  --controller-namespace=sealed-secrets \
+  > pub-sealed-secrets.pem
+
+# Seal the secret
+kubeseal --format yaml \
+  --cert pub-sealed-secrets.pem \
+  < secret.yaml \
+  > sealed-secret.yaml
+
+# Delete the original secret!
+rm secret.yaml
+```
+
+### 4. Commit the SealedSecret
+
+```bash
+# sealed-secret.yaml is safe to commit
+git add sealed-secret.yaml
+git commit -m "Add sealed secret for my-app"
+```
+
+## Scope Options
+
+### Strict (default)
+- Bound to exact name and namespace
+- Most secure option
+
+```bash
+kubeseal --scope strict ...
+```
+
+### Namespace-wide
+- Can be renamed within the same namespace
+
+```bash
+kubeseal --scope namespace-wide ...
+```
+
+### Cluster-wide
+- Can be decrypted in any namespace
+- Least secure, use sparingly
+
+```bash
+kubeseal --scope cluster-wide ...
+```

--- a/kubernetes/sealed-secrets/examples/database-secret.yaml
+++ b/kubernetes/sealed-secrets/examples/database-secret.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Example: Database credentials SealedSecret
+#
+# This is an EXAMPLE template. In real usage:
+# 1. Create the actual secret with real credentials
+# 2. Use kubeseal to encrypt it
+# 3. Replace this file with the encrypted output
+#
+# To create from actual credentials:
+# cat <<EOF | kubeseal --format yaml > database-secret.yaml
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: database-credentials
+#   namespace: default
+# type: Opaque
+# stringData:
+#   DB_HOST: your-db-host
+#   DB_PORT: "5432"
+#   DB_NAME: myapp
+#   DB_USER: myapp_user
+#   DB_PASSWORD: your-super-secret-password
+# EOF
+#
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: database-credentials
+  namespace: default
+  annotations:
+    sealedsecrets.bitnami.com/managed: "true"
+spec:
+  encryptedData:
+    # These are PLACEHOLDER values - replace with actual kubeseal output
+    DB_HOST: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+    DB_PORT: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+    DB_NAME: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+    DB_USER: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+    DB_PASSWORD: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+  template:
+    metadata:
+      name: database-credentials
+      namespace: default
+      labels:
+        app.kubernetes.io/name: myapp
+        app.kubernetes.io/component: database
+    type: Opaque

--- a/kubernetes/sealed-secrets/examples/docker-registry-secret.yaml
+++ b/kubernetes/sealed-secrets/examples/docker-registry-secret.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Example: Docker Registry credentials SealedSecret
+#
+# To create from actual credentials:
+#
+# kubectl create secret docker-registry regcred \
+#   --docker-server=asia-southeast1-docker.pkg.dev \
+#   --docker-username=_json_key \
+#   --docker-password="$(cat service-account-key.json)" \
+#   --docker-email=sa@project.iam.gserviceaccount.com \
+#   --dry-run=client -o yaml | kubeseal --format yaml > docker-registry-secret.yaml
+#
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: regcred
+  namespace: default
+  annotations:
+    sealedsecrets.bitnami.com/managed: "true"
+spec:
+  encryptedData:
+    # PLACEHOLDER - replace with actual kubeseal output
+    .dockerconfigjson: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+  template:
+    metadata:
+      name: regcred
+      namespace: default
+      labels:
+        app.kubernetes.io/name: registry-credentials
+    type: kubernetes.io/dockerconfigjson

--- a/kubernetes/sealed-secrets/examples/tls-secret.yaml
+++ b/kubernetes/sealed-secrets/examples/tls-secret.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Example: TLS certificate SealedSecret
+#
+# To create from actual certificates:
+#
+# kubectl create secret tls my-tls-secret \
+#   --cert=path/to/tls.crt \
+#   --key=path/to/tls.key \
+#   --dry-run=client -o yaml | kubeseal --format yaml > tls-secret.yaml
+#
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: my-tls-secret
+  namespace: default
+  annotations:
+    sealedsecrets.bitnami.com/managed: "true"
+spec:
+  encryptedData:
+    # PLACEHOLDER - replace with actual kubeseal output
+    tls.crt: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+    tls.key: AgBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
+  template:
+    metadata:
+      name: my-tls-secret
+      namespace: default
+      labels:
+        app.kubernetes.io/name: tls-certificate
+    type: kubernetes.io/tls

--- a/kubernetes/sealed-secrets/kustomization.yaml
+++ b/kubernetes/sealed-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base/


### PR DESCRIPTION
## Summary
- Add Sealed Secrets controller manifests with CRD, RBAC, and deployment
- Add example sealed secrets templates (database credentials, Docker registry, TLS)
- Add ArgoCD applications for Gatekeeper and Sealed Secrets GitOps workflow
- Add comprehensive documentation for usage and best practices

## Changes
- `kubernetes/sealed-secrets/base/` - Controller manifests
- `kubernetes/sealed-secrets/examples/` - Example templates
- `kubernetes/argocd/applications/` - ArgoCD apps
- `docs/sealed-secrets.md` - Documentation

## Test Plan
- [ ] Deploy controller to cluster
- [ ] Verify kubeseal can connect
- [ ] Test sealing and unsealing secrets
- [ ] Verify ArgoCD sync

Closes #5