### PR TITLE
feat: add multi-environment promotion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Production-ready GCP infrastructure using Terraform with full DevOps pipeline.
 - **Cloud SQL**: Managed PostgreSQL with high availability
 - **Artifact Registry**: Private Docker image repository
 - **Cloud Build**: CI/CD pipeline with GitOps
+- **Multi-Environment Promotion**: Automated dev → staging → prod pipeline
 - **Secret Manager**: Secure credential management
 - **Cloud Monitoring**: Metrics, logging, and alerting
 - **ArgoCD**: GitOps continuous deployment
@@ -149,7 +150,12 @@ gcp-devops-iac/
 │   ├── grafana/            # Grafana dashboards
 │   └── apps/               # Application deployments
 ├── cloudbuild/
-│   └── cloudbuild.yaml     # CI/CD pipeline config
+│   ├── cloudbuild.yaml          # CI/CD pipeline config
+│   ├── cloudbuild-promote.yaml  # Multi-env promotion
+│   └── triggers/                # Trigger configurations
+├── scripts/
+│   ├── smoke-test.sh            # Automated smoke tests
+│   └── rollback.sh              # Emergency rollback
 └── docs/
     └── architecture.md
 ```

--- a/cloudbuild/cloudbuild-promote.yaml
+++ b/cloudbuild/cloudbuild-promote.yaml
@@ -1,0 +1,145 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Multi-Environment Promotion Pipeline
+#
+# Pipeline Flow:
+#   dev → (auto tests) → staging → (manual approval) → prod
+#
+# Triggers:
+#   - Dev: On merge to main
+#   - Staging: Triggered by successful dev deployment
+#   - Prod: Manual approval required
+#
+substitutions:
+  _ENV: 'dev'
+  _IMAGE_TAG: '${SHORT_SHA}'
+  _CLUSTER_NAME: 'gke-cluster'
+  _CLUSTER_REGION: 'asia-southeast1'
+  _PROJECT_ID: '${PROJECT_ID}'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'
+
+steps:
+  # ============================================
+  # Step 1: Build and Push Image
+  # ============================================
+  - id: 'build-image'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker build \
+          --tag "asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_IMAGE_TAG}" \
+          --tag "asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_ENV}-latest" \
+          --cache-from "asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_ENV}-latest" \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          .
+        docker push "asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_IMAGE_TAG}"
+        docker push "asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_ENV}-latest"
+
+  # ============================================
+  # Step 2: Update Kustomization with new image
+  # ============================================
+  - id: 'update-kustomization'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Install kustomize
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        mv kustomize /usr/local/bin/
+
+        # Update image tag in kustomization
+        cd kubernetes/apps/overlays/${_ENV}
+        kustomize edit set image app=asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_IMAGE_TAG}
+
+        # Output rendered manifests for verification
+        echo "=== Rendered manifests for ${_ENV} ==="
+        kustomize build .
+
+  # ============================================
+  # Step 3: Deploy to target environment
+  # ============================================
+  - id: 'deploy'
+    name: 'gcr.io/cloud-builders/gke-deploy'
+    args:
+      - 'run'
+      - '--filename=kubernetes/apps/overlays/${_ENV}'
+      - '--cluster=${_CLUSTER_NAME}'
+      - '--location=${_CLUSTER_REGION}'
+      - '--project=${_PROJECT_ID}'
+
+  # ============================================
+  # Step 4: Wait for rollout
+  # ============================================
+  - id: 'wait-rollout'
+    name: 'gcr.io/cloud-builders/kubectl'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gcloud container clusters get-credentials ${_CLUSTER_NAME} \
+          --region ${_CLUSTER_REGION} \
+          --project ${_PROJECT_ID}
+
+        NAMESPACE="app-${_ENV}"
+        DEPLOYMENT="${_ENV}-app"
+
+        echo "Waiting for rollout of ${DEPLOYMENT} in ${NAMESPACE}..."
+        kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=300s
+
+        echo "Rollout completed successfully!"
+        kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=app
+
+  # ============================================
+  # Step 5: Run smoke tests
+  # ============================================
+  - id: 'smoke-tests'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        chmod +x scripts/smoke-test.sh
+        ./scripts/smoke-test.sh ${_ENV}
+
+  # ============================================
+  # Step 6: Trigger next environment (if applicable)
+  # ============================================
+  - id: 'trigger-promotion'
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        case "${_ENV}" in
+          "dev")
+            echo "Dev deployment successful. Triggering staging promotion..."
+            gcloud builds triggers run promote-to-staging \
+              --project=${_PROJECT_ID} \
+              --substitutions=_IMAGE_TAG=${_IMAGE_TAG}
+            ;;
+          "staging")
+            echo "Staging deployment successful."
+            echo "Production deployment requires manual approval."
+            echo ""
+            echo "To promote to production, run:"
+            echo "  gcloud builds triggers run promote-to-prod --substitutions=_IMAGE_TAG=${_IMAGE_TAG}"
+            ;;
+          "prod")
+            echo "Production deployment completed successfully!"
+            echo "Image tag: ${_IMAGE_TAG}"
+            ;;
+        esac
+
+# Artifact metadata
+artifacts:
+  images:
+    - 'asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_IMAGE_TAG}'
+    - 'asia-southeast1-docker.pkg.dev/${_PROJECT_ID}/repo/app:${_ENV}-latest'
+
+# Build timeout
+timeout: '1200s'

--- a/cloudbuild/triggers/dev-deploy.yaml
+++ b/cloudbuild/triggers/dev-deploy.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Cloud Build Trigger: Deploy to Development
+#
+# Trigger: On push to main branch
+# Action: Build and deploy to dev environment
+#
+name: deploy-to-dev
+description: Deploy to development environment on main branch push
+
+github:
+  owner: bimakw
+  name: gcp-devops-iac
+  push:
+    branch: ^main$
+
+filename: cloudbuild/cloudbuild-promote.yaml
+
+substitutions:
+  _ENV: dev
+
+includedFiles:
+  - 'src/**'
+  - 'kubernetes/apps/**'
+  - 'Dockerfile'
+
+tags:
+  - deploy
+  - dev
+  - automated

--- a/cloudbuild/triggers/prod-promote.yaml
+++ b/cloudbuild/triggers/prod-promote.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Cloud Build Trigger: Promote to Production
+#
+# Trigger: Manual approval required
+# Action: Deploy to production environment
+#
+# IMPORTANT: This trigger should be configured with approval requirements
+# in GCP Console: Cloud Build > Triggers > Edit > Approval
+#
+name: promote-to-prod
+description: Promote to production (requires manual approval)
+
+# Manual/API trigger only
+triggerTemplate:
+  projectId: ${PROJECT_ID}
+  branchName: main
+
+filename: cloudbuild/cloudbuild-promote.yaml
+
+substitutions:
+  _ENV: prod
+
+# Requires approval before execution
+# Configure in GCP Console:
+#   1. Edit trigger
+#   2. Enable "Require approval before build executes"
+#   3. Add approvers (users/groups)
+#
+# Alternatively, use Cloud Build Approvals API:
+#   gcloud builds approve BUILD_ID
+
+tags:
+  - deploy
+  - production
+  - approval-required

--- a/cloudbuild/triggers/staging-promote.yaml
+++ b/cloudbuild/triggers/staging-promote.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Cloud Build Trigger: Promote to Staging
+#
+# Trigger: Called by dev deployment after successful tests
+# Action: Deploy to staging environment
+#
+name: promote-to-staging
+description: Promote to staging environment (triggered by dev success)
+
+# Manual/API trigger only - no automatic git trigger
+triggerTemplate:
+  projectId: ${PROJECT_ID}
+  branchName: main
+
+filename: cloudbuild/cloudbuild-promote.yaml
+
+substitutions:
+  _ENV: staging
+
+# Requires the image tag from dev deployment
+# Passed via: --substitutions=_IMAGE_TAG=xxx
+
+tags:
+  - deploy
+  - staging
+  - promotion

--- a/docs/promotion-pipeline.md
+++ b/docs/promotion-pipeline.md
@@ -1,0 +1,303 @@
+# Multi-Environment Promotion Pipeline
+
+Copyright (c) 2024 Bima Kharisma Wicaksana
+
+## Overview
+
+Pipeline otomatis untuk promosi deployment antar environment dengan approval gates dan automated testing.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     Multi-Environment Pipeline                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  GitHub                Cloud Build                    GKE Clusters       │
+│  ┌──────────┐         ┌───────────┐                  ┌──────────────┐   │
+│  │  Push to │────────▶│  Build &  │─────────────────▶│     DEV      │   │
+│  │   main   │         │   Test    │                  │  (app-dev)   │   │
+│  └──────────┘         └─────┬─────┘                  └──────┬───────┘   │
+│                             │                               │           │
+│                             │ Smoke Tests Pass              │           │
+│                             ▼                               ▼           │
+│                       ┌───────────┐                  ┌──────────────┐   │
+│                       │  Auto     │─────────────────▶│   STAGING    │   │
+│                       │  Promote  │                  │(app-staging) │   │
+│                       └─────┬─────┘                  └──────┬───────┘   │
+│                             │                               │           │
+│                             │ Manual Approval               │           │
+│                             ▼                               ▼           │
+│                       ┌───────────┐                  ┌──────────────┐   │
+│                       │  Approved │─────────────────▶│    PROD      │   │
+│                       │  Deploy   │                  │  (app-prod)  │   │
+│                       └───────────┘                  └──────────────┘   │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Pipeline Flow
+
+### 1. Development (Automatic)
+
+```
+Push to main → Build Image → Deploy to Dev → Smoke Tests → Auto-promote to Staging
+```
+
+### 2. Staging (Automatic)
+
+```
+Staging Deploy → Smoke Tests → Wait for Approval
+```
+
+### 3. Production (Manual Approval)
+
+```
+Approval Request → Approved → Deploy to Prod → Smoke Tests → Complete
+```
+
+## Environment Differences
+
+| Aspect | Dev | Staging | Prod |
+|--------|-----|---------|------|
+| Replicas | 1 | 2 | 3-10 |
+| CPU Request | 50m | 100m | 200m |
+| Memory Request | 64Mi | 128Mi | 256Mi |
+| CPU Limit | 200m | 500m | 1000m |
+| Memory Limit | 256Mi | 512Mi | 1Gi |
+| HPA Min | 1 | 2 | 3 |
+| HPA Max | 2 | 5 | 10 |
+| Log Level | debug | info | warn |
+| PDB | No | No | Yes (min 2) |
+
+## Setup
+
+### 1. Create Cloud Build Triggers
+
+```bash
+# Deploy to Dev (on push to main)
+gcloud builds triggers create github \
+  --name="deploy-to-dev" \
+  --repo-name="gcp-devops-iac" \
+  --repo-owner="bimakw" \
+  --branch-pattern="^main$" \
+  --build-config="cloudbuild/cloudbuild-promote.yaml" \
+  --substitutions="_ENV=dev"
+
+# Promote to Staging (triggered by dev)
+gcloud builds triggers create manual \
+  --name="promote-to-staging" \
+  --build-config="cloudbuild/cloudbuild-promote.yaml" \
+  --substitutions="_ENV=staging"
+
+# Promote to Production (requires approval)
+gcloud builds triggers create manual \
+  --name="promote-to-prod" \
+  --build-config="cloudbuild/cloudbuild-promote.yaml" \
+  --substitutions="_ENV=prod" \
+  --require-approval
+```
+
+### 2. Configure Approval (Production)
+
+```bash
+# Add approvers for production trigger
+gcloud builds triggers update promote-to-prod \
+  --require-approval \
+  --approval-config-file=cloudbuild/approval-config.yaml
+```
+
+### 3. Create GKE Namespaces
+
+```bash
+# Dev
+kubectl apply -k kubernetes/apps/overlays/dev
+
+# Staging
+kubectl apply -k kubernetes/apps/overlays/staging
+
+# Production
+kubectl apply -k kubernetes/apps/overlays/prod
+```
+
+## Usage
+
+### Deploy to Development
+
+Automatic on push to main:
+
+```bash
+git push origin main
+```
+
+### Promote to Staging
+
+Automatic after dev tests pass, or manual:
+
+```bash
+gcloud builds triggers run promote-to-staging \
+  --substitutions=_IMAGE_TAG=abc123
+```
+
+### Promote to Production
+
+Requires approval:
+
+```bash
+# Request deployment
+gcloud builds triggers run promote-to-prod \
+  --substitutions=_IMAGE_TAG=abc123
+
+# Approve the build (done by approver)
+gcloud builds approve BUILD_ID
+```
+
+### Rollback
+
+Emergency rollback to previous version:
+
+```bash
+# Rollback to previous version
+./scripts/rollback.sh prod
+
+# Rollback to specific revision
+./scripts/rollback.sh prod 5
+```
+
+## Smoke Tests
+
+Automated tests run after each deployment:
+
+| Test | Description |
+|------|-------------|
+| Namespace exists | Verify namespace is created |
+| Deployment ready | Check replicas are running |
+| Pods running | Verify pods are healthy |
+| Service exists | Check service is created |
+| HPA configured | Verify autoscaling is set |
+| Health endpoint | Test /health returns 200 |
+| Ready endpoint | Test /ready returns 200 |
+| Metrics endpoint | Test /metrics returns 200 |
+| Resource limits | Verify limits are set |
+| Liveness probe | Check probe is configured |
+| Readiness probe | Check probe is configured |
+| Security context | Verify security settings |
+
+Run manually:
+
+```bash
+./scripts/smoke-test.sh dev
+./scripts/smoke-test.sh staging
+./scripts/smoke-test.sh prod
+```
+
+## Kustomize Structure
+
+```
+kubernetes/apps/
+├── base/
+│   ├── deployment.yaml      # Base deployment template
+│   ├── service.yaml         # Service definition
+│   ├── hpa.yaml             # HPA template
+│   └── kustomization.yaml
+└── overlays/
+    ├── dev/
+    │   └── kustomization.yaml   # Dev overrides
+    ├── staging/
+    │   └── kustomization.yaml   # Staging overrides
+    └── prod/
+        ├── kustomization.yaml   # Prod overrides
+        └── pdb.yaml             # Pod Disruption Budget
+```
+
+### Preview Changes
+
+```bash
+# Preview dev manifests
+kustomize build kubernetes/apps/overlays/dev
+
+# Preview staging manifests
+kustomize build kubernetes/apps/overlays/staging
+
+# Preview prod manifests
+kustomize build kubernetes/apps/overlays/prod
+```
+
+## Best Practices
+
+### 1. Image Tags
+
+- Dev: `dev-latest` (rolling)
+- Staging: `staging-latest` (rolling)
+- Prod: `v1.2.3` (immutable semantic version)
+
+### 2. Approval Process
+
+- Always require 2 approvers for production
+- Document reason for each production deployment
+- Keep audit trail of approvals
+
+### 3. Rollback Strategy
+
+- Keep last 10 revisions for each deployment
+- Document rollback procedures
+- Practice rollback in staging first
+
+### 4. Monitoring
+
+- Set up alerts for failed deployments
+- Monitor error rate after each promotion
+- Use canary deployments for high-risk changes
+
+## Troubleshooting
+
+### Build Failed
+
+```bash
+# Check build logs
+gcloud builds log BUILD_ID
+
+# Retry build
+gcloud builds triggers run TRIGGER_NAME
+```
+
+### Deployment Stuck
+
+```bash
+# Check deployment status
+kubectl rollout status deployment/prod-app -n app-prod
+
+# Check pod events
+kubectl describe pods -n app-prod -l app.kubernetes.io/name=app
+```
+
+### Smoke Tests Failed
+
+```bash
+# Run tests manually
+./scripts/smoke-test.sh prod
+
+# Check pod logs
+kubectl logs -n app-prod -l app.kubernetes.io/name=app
+```
+
+## File Structure
+
+```
+cloudbuild/
+├── cloudbuild-promote.yaml    # Main promotion pipeline
+└── triggers/
+    ├── dev-deploy.yaml        # Dev trigger config
+    ├── staging-promote.yaml   # Staging trigger config
+    └── prod-promote.yaml      # Prod trigger config
+
+scripts/
+├── smoke-test.sh              # Smoke test script
+└── rollback.sh                # Rollback script
+```
+
+## References
+
+- [Cloud Build Approvals](https://cloud.google.com/build/docs/securing-builds/gate-builds-on-approval)
+- [Kustomize Documentation](https://kustomize.io/)
+- [GKE Deployment Best Practices](https://cloud.google.com/kubernetes-engine/docs/best-practices/deploying-workloads)

--- a/kubernetes/apps/base/deployment.yaml
+++ b/kubernetes/apps/base/deployment.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Base deployment template - customized per environment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/name: app
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: app
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: app:latest
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: ENV
+              value: "development"
+            - name: LOG_LEVEL
+              value: "debug"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/name: app

--- a/kubernetes/apps/base/hpa.yaml
+++ b/kubernetes/apps/base/hpa.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Horizontal Pod Autoscaler - values customized per environment
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/name: app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: app
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 4
+          periodSeconds: 15
+      selectPolicy: Max

--- a/kubernetes/apps/base/kustomization.yaml
+++ b/kubernetes/apps/base/kustomization.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - hpa.yaml
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: sample-app

--- a/kubernetes/apps/base/namespace.yaml
+++ b/kubernetes/apps/base/namespace.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Base namespace - will be overridden by overlays
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/managed-by: kustomize

--- a/kubernetes/apps/base/service.yaml
+++ b/kubernetes/apps/base/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/name: app
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: app

--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Development Environment Overlay
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: app-dev
+
+resources:
+  - ../../base
+
+namePrefix: dev-
+
+commonLabels:
+  environment: development
+  tier: dev
+
+commonAnnotations:
+  note: "Development environment - not for production use"
+
+# Environment-specific patches
+patches:
+  # Deployment patches
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: app
+      spec:
+        replicas: 1
+        template:
+          spec:
+            containers:
+              - name: app
+                env:
+                  - name: ENV
+                    value: "development"
+                  - name: LOG_LEVEL
+                    value: "debug"
+                  - name: DEBUG
+                    value: "true"
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 200m
+                    memory: 256Mi
+
+  # HPA patches - minimal scaling for dev
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: app
+      spec:
+        minReplicas: 1
+        maxReplicas: 2
+
+# Image configuration - override with actual image
+images:
+  - name: app
+    newName: asia-southeast1-docker.pkg.dev/PROJECT_ID/repo/app
+    newTag: dev-latest
+
+# ConfigMap for dev environment
+configMapGenerator:
+  - name: app-config
+    literals:
+      - DATABASE_HOST=postgres-dev.db.svc.cluster.local
+      - REDIS_HOST=redis-dev.cache.svc.cluster.local
+      - FEATURE_FLAGS=debug,profiling

--- a/kubernetes/apps/overlays/prod/kustomization.yaml
+++ b/kubernetes/apps/overlays/prod/kustomization.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Production Environment Overlay
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: app-prod
+
+resources:
+  - ../../base
+  - pdb.yaml
+
+namePrefix: prod-
+
+commonLabels:
+  environment: production
+  tier: prod
+
+commonAnnotations:
+  note: "Production environment - handle with care"
+
+# Environment-specific patches
+patches:
+  # Deployment patches
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: app
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+            maxSurge: 1
+        template:
+          spec:
+            topologySpreadConstraints:
+              - maxSkew: 1
+                topologyKey: topology.kubernetes.io/zone
+                whenUnsatisfiable: ScheduleAnyway
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: app
+            containers:
+              - name: app
+                env:
+                  - name: ENV
+                    value: "production"
+                  - name: LOG_LEVEL
+                    value: "warn"
+                  - name: DEBUG
+                    value: "false"
+                resources:
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1000m
+                    memory: 1Gi
+
+  # HPA patches - full scaling for production
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: app
+      spec:
+        minReplicas: 3
+        maxReplicas: 10
+
+# Image configuration - use specific version tag
+images:
+  - name: app
+    newName: asia-southeast1-docker.pkg.dev/PROJECT_ID/repo/app
+    newTag: v1.0.0
+
+# ConfigMap for production environment
+configMapGenerator:
+  - name: app-config
+    literals:
+      - DATABASE_HOST=postgres-prod.db.svc.cluster.local
+      - REDIS_HOST=redis-prod.cache.svc.cluster.local
+      - FEATURE_FLAGS=

--- a/kubernetes/apps/overlays/prod/pdb.yaml
+++ b/kubernetes/apps/overlays/prod/pdb.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Pod Disruption Budget for Production
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: app-pdb
+  labels:
+    app.kubernetes.io/name: app
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app

--- a/kubernetes/apps/overlays/staging/kustomization.yaml
+++ b/kubernetes/apps/overlays/staging/kustomization.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Staging Environment Overlay
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: app-staging
+
+resources:
+  - ../../base
+
+namePrefix: staging-
+
+commonLabels:
+  environment: staging
+  tier: staging
+
+commonAnnotations:
+  note: "Staging environment - pre-production validation"
+
+# Environment-specific patches
+patches:
+  # Deployment patches
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: app
+      spec:
+        replicas: 2
+        template:
+          spec:
+            containers:
+              - name: app
+                env:
+                  - name: ENV
+                    value: "staging"
+                  - name: LOG_LEVEL
+                    value: "info"
+                  - name: DEBUG
+                    value: "false"
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+
+  # HPA patches - moderate scaling for staging
+  - patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: app
+      spec:
+        minReplicas: 2
+        maxReplicas: 5
+
+# Image configuration
+images:
+  - name: app
+    newName: asia-southeast1-docker.pkg.dev/PROJECT_ID/repo/app
+    newTag: staging-latest
+
+# ConfigMap for staging environment
+configMapGenerator:
+  - name: app-config
+    literals:
+      - DATABASE_HOST=postgres-staging.db.svc.cluster.local
+      - REDIS_HOST=redis-staging.cache.svc.cluster.local
+      - FEATURE_FLAGS=metrics

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Rollback Script for Emergency Recovery
+#
+# Usage: ./rollback.sh <environment> [revision]
+# Example: ./rollback.sh prod
+# Example: ./rollback.sh prod 3
+
+set -e
+
+ENV=${1:-dev}
+REVISION=${2:-}
+NAMESPACE="app-${ENV}"
+DEPLOYMENT="${ENV}-app"
+
+echo "============================================"
+echo "Rollback for ${ENV} environment"
+echo "============================================"
+echo ""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Show current status
+echo "=== Current Deployment Status ==="
+kubectl get deployment ${DEPLOYMENT} -n ${NAMESPACE} -o wide
+echo ""
+
+# Show rollout history
+echo "=== Rollout History ==="
+kubectl rollout history deployment/${DEPLOYMENT} -n ${NAMESPACE}
+echo ""
+
+# Perform rollback
+if [ -n "${REVISION}" ]; then
+    echo -e "${YELLOW}Rolling back to revision ${REVISION}...${NC}"
+    kubectl rollout undo deployment/${DEPLOYMENT} -n ${NAMESPACE} --to-revision=${REVISION}
+else
+    echo -e "${YELLOW}Rolling back to previous revision...${NC}"
+    kubectl rollout undo deployment/${DEPLOYMENT} -n ${NAMESPACE}
+fi
+
+# Wait for rollback to complete
+echo ""
+echo "Waiting for rollback to complete..."
+kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=300s
+
+# Show new status
+echo ""
+echo "=== New Deployment Status ==="
+kubectl get deployment ${DEPLOYMENT} -n ${NAMESPACE} -o wide
+echo ""
+
+# Show pods
+echo "=== Pod Status ==="
+kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=app
+echo ""
+
+echo -e "${GREEN}Rollback completed successfully!${NC}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Copyright (c) 2024 Bima Kharisma Wicaksana
+# Smoke Test Script for Environment Validation
+#
+# Usage: ./smoke-test.sh <environment>
+# Example: ./smoke-test.sh dev
+
+set -e
+
+ENV=${1:-dev}
+NAMESPACE="app-${ENV}"
+SERVICE_NAME="${ENV}-app"
+
+echo "============================================"
+echo "Running smoke tests for ${ENV} environment"
+echo "============================================"
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+PASSED=0
+FAILED=0
+
+# Test function
+run_test() {
+    local test_name=$1
+    local test_command=$2
+
+    echo -n "Testing: ${test_name}... "
+
+    if eval "${test_command}" > /dev/null 2>&1; then
+        echo -e "${GREEN}PASSED${NC}"
+        ((PASSED++))
+        return 0
+    else
+        echo -e "${RED}FAILED${NC}"
+        ((FAILED++))
+        return 1
+    fi
+}
+
+# Get service endpoint
+get_service_endpoint() {
+    kubectl get svc ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}'
+}
+
+echo "=== Infrastructure Tests ==="
+echo ""
+
+# Test 1: Namespace exists
+run_test "Namespace exists" "kubectl get namespace ${NAMESPACE}"
+
+# Test 2: Deployment exists and has ready replicas
+run_test "Deployment is ready" "kubectl get deployment ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.status.readyReplicas}' | grep -v '^0$'"
+
+# Test 3: Pods are running
+run_test "Pods are running" "kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name=app --field-selector=status.phase=Running | grep -q ${SERVICE_NAME}"
+
+# Test 4: Service exists
+run_test "Service exists" "kubectl get svc ${SERVICE_NAME} -n ${NAMESPACE}"
+
+# Test 5: HPA exists
+run_test "HPA is configured" "kubectl get hpa ${SERVICE_NAME} -n ${NAMESPACE}"
+
+echo ""
+echo "=== Endpoint Tests ==="
+echo ""
+
+# Get the service endpoint for HTTP tests
+SERVICE_IP=$(get_service_endpoint 2>/dev/null || echo "")
+
+if [ -n "${SERVICE_IP}" ]; then
+    # Test 6: Health endpoint
+    run_test "Health endpoint responds" "kubectl run smoke-test-${RANDOM} --rm -i --restart=Never --image=curlimages/curl -- curl -sf http://${SERVICE_IP}/health --connect-timeout 5"
+
+    # Test 7: Ready endpoint
+    run_test "Ready endpoint responds" "kubectl run smoke-test-${RANDOM} --rm -i --restart=Never --image=curlimages/curl -- curl -sf http://${SERVICE_IP}/ready --connect-timeout 5"
+
+    # Test 8: Metrics endpoint
+    run_test "Metrics endpoint responds" "kubectl run smoke-test-${RANDOM} --rm -i --restart=Never --image=curlimages/curl -- curl -sf http://${SERVICE_IP}/metrics --connect-timeout 5"
+else
+    echo -e "${YELLOW}WARNING: Could not get service IP, skipping endpoint tests${NC}"
+fi
+
+echo ""
+echo "=== Resource Tests ==="
+echo ""
+
+# Test 9: Resource limits are set
+run_test "Resource limits configured" "kubectl get deployment ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].resources.limits}' | grep -q 'cpu'"
+
+# Test 10: Liveness probe configured
+run_test "Liveness probe configured" "kubectl get deployment ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].livenessProbe}' | grep -q 'httpGet'"
+
+# Test 11: Readiness probe configured
+run_test "Readiness probe configured" "kubectl get deployment ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}' | grep -q 'httpGet'"
+
+# Test 12: Security context configured
+run_test "Security context configured" "kubectl get deployment ${SERVICE_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.securityContext}' | grep -q 'runAsNonRoot'"
+
+echo ""
+echo "============================================"
+echo "Smoke Test Results"
+echo "============================================"
+echo -e "Passed: ${GREEN}${PASSED}${NC}"
+echo -e "Failed: ${RED}${FAILED}${NC}"
+echo ""
+
+# Exit with failure if any tests failed
+if [ ${FAILED} -gt 0 ]; then
+    echo -e "${RED}Smoke tests FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All smoke tests PASSED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Add Kustomize base and overlays for dev/staging/prod environments
- Add Cloud Build promotion pipeline with automated triggers
- Add smoke test script for deployment validation
- Add rollback script for emergency recovery
- Add comprehensive documentation

## Pipeline Flow
```
dev → (auto) → staging → (manual approval) → prod
```

## Environment Configuration
| Environment | Replicas | CPU | Memory | HPA | PDB |
|-------------|----------|-----|--------|-----|-----|
| Dev | 1 | 50-200m | 64-256Mi | 1-2 | No |
| Staging | 2 | 100-500m | 128-512Mi | 2-5 | No |
| Prod | 3 | 200-1000m | 256Mi-1Gi | 3-10 | Yes |

## Test Plan
- [ ] Preview Kustomize manifests for each environment
- [ ] Test Cloud Build trigger configuration
- [ ] Run smoke tests locally
- [ ] Test rollback script

Closes #9